### PR TITLE
Use bundled question file as default quiz bank

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,9 +131,7 @@
                         <div class="d-flex flex-wrap gap-2 mt-2">
                             <button class="btn btn-sm btn-outline-primary" @click="loadSample()"><i
                                     class="bi bi-lightning-charge" aria-hidden="true"></i> 載入範例題庫</button>
-                            <button class="btn btn-sm btn-outline-secondary" @click="loadCurrentQuestions()"><i
-                                    class="bi bi-upload" aria-hidden="true"></i> 載入目前題庫</button>
-                            <button class="btn btn-sm btn-outline-secondary" @click="loadDefaultQuestions()"><i
+                            <button class="btn btn-sm btn-outline-secondary" @click="loadProjectQuestions()"><i
                                     class="bi bi-file-earmark" aria-hidden="true"></i> 載入專案題庫</button>
                             <button class="btn btn-sm btn-outline-secondary" :disabled="questions.length===0"
                                 @click="downloadQuestions()"><i class="bi bi-download" aria-hidden="true"></i>
@@ -610,14 +608,14 @@
                 async init() {
                     // 從 LocalStorage 載入紀錄
                     this.loadStatsFromLS();
-                    await this.loadDefaultQuestions();
+                    await this.loadProjectQuestions();
                     await this.loadStatsFromFile();
                 },
 
                 // 預設載入題庫與紀錄檔
-                async loadDefaultQuestions() {
+                async loadProjectQuestions() {
                     try {
-                        const res = await fetch('question.json');
+                        const res = await fetch('question.json', { cache: 'no-store' });
                         if (res.ok) {
                             const arr = await res.json();
                             if (Array.isArray(arr)) {
@@ -665,19 +663,6 @@
                     ];
                     this.syncStatsWithQuestions();
                     this.numQuestions = Math.min(10, this.questions.length);
-                },
-                async loadCurrentQuestions() {
-                    try {
-                        const res = await fetch('question_json_20250812_223956.json');
-                        if (res.ok) {
-                            const arr = await res.json();
-                            if (Array.isArray(arr)) {
-                                this.questions = arr;
-                                this.syncStatsWithQuestions();
-                                this.numQuestions = Math.min(10, this.questions.length || 10);
-                            }
-                        }
-                    } catch (err) { alert('載入目前題庫失敗：' + err.message); }
                 },
                 downloadQuestions() {
                     if (!this.questions?.length) { alert('尚未載入題庫'); return; }


### PR DESCRIPTION
## Summary
- Remove unused `loadCurrentQuestions` flow and button
- Always load `question.json` as the project question bank with no caching

## Testing
- `python -m json.tool question.json`

------
https://chatgpt.com/codex/tasks/task_e_689b66c79e2c8325a477f52cd7f0827b