### PR TITLE
Fix single-question mode navigation and timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
                     </template>
 
                     <template x-if="quizSet.length>0">
-                        <div class="mt-3" x-data="questionVM(quizSet[currentIndex])" x-init="qInit()"
+                        <div class="mt-3" x-data="questionVM(quizSet[currentIndex])" x-init="qInit()" :key="currentIndex"
                             @submit-one.window="onSubmitFromParent($event)">
                             <div class="d-flex align-items-start justify-content-between">
                                 <div>
@@ -584,6 +584,7 @@
                 showHelp: false,
                 debugMode: false,
                 // 計時相關
+                perQuestionSec: 60,    // 每題秒數
                 timer: null,
                 timeLimitSec: 0,
                 remainingSec: 0,
@@ -767,9 +768,13 @@
                     this.quizSet = pool.slice(0, Math.min(this.numQuestions, pool.length));
                     // 初始化已選答案容器
                     this.quizSet.forEach(q => { this.answers[q.id] = new Set(); this.easyMarkAll[q.id] = false; });
-                    // 計時：每題 1 分鐘，最多 60 分鐘
-                    const totalSec = Math.min(60 * 60, this.quizSet.length * 60);
-                    this.timeLimitSec = totalSec;
+                    // 計時：每題固定秒數
+                    if (this.pageMode === 'one') {
+                        this.timeLimitSec = this.perQuestionSec;
+                    } else {
+                        const totalSec = Math.min(60 * 60, this.quizSet.length * this.perQuestionSec);
+                        this.timeLimitSec = totalSec;
+                    }
                     this.startTimer();
                 },
 
@@ -788,8 +793,20 @@
                 },
 
                 // —— 一頁一題：導覽與收尾 ——
-                prev() { if (this.currentIndex > 0) { this.currentIndex--; window.scrollTo({ top: 0, behavior: 'smooth' }); } },
-                next() { if (this.currentIndex < this.quizSet.length - 1) { this.currentIndex++; window.scrollTo({ top: 0, behavior: 'smooth' }); } },
+                prev() {
+                    if (this.currentIndex > 0) {
+                        this.currentIndex--;
+                        if (this.pageMode === 'one') { this.timeLimitSec = this.perQuestionSec; this.startTimer(); }
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                    }
+                },
+                next() {
+                    if (this.currentIndex < this.quizSet.length - 1) {
+                        this.currentIndex++;
+                        if (this.pageMode === 'one') { this.timeLimitSec = this.perQuestionSec; this.startTimer(); }
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                    }
+                },
                 finishAndSummary() {
                     clearInterval(this.timer);
                     // 計算本輪統計（以 resultMap 為準；單題模式尚未提交的不算）


### PR DESCRIPTION
## Summary
- Ensure single-question view re-renders on navigation and reset timer each question
- Add per-question timer configuration and restart timer on next/previous

## Testing
- `npx prettier --check index.html` (fails: Code style issues found)
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_689b69cda56083258a5ce85548d2e60d