### PR TITLE
Fix single-question navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,8 @@
                     </template>
 
                     <template x-if="quizSet.length>0">
-                        <div class="mt-3" x-data="questionVM(quizSet[currentIndex])" x-init="qInit()" :key="currentIndex"
+                        <div class="mt-3" x-data="questionVM()" x-init="qInit()"
+                            x-effect="loadQuestion($root.quizSet[$root.currentIndex])"
                             @submit-one.window="onSubmitFromParent($event)">
                             <div class="d-flex align-items-start justify-content-between">
                                 <div>
@@ -883,11 +884,11 @@
         }
 
         // —— 單題元件 VM ——
-        function questionVM(q) {
+        function questionVM() {
             return {
-                q,
+                q: null,
                 stat: null,
-                isMulti: (q.answer?.length || 0) > 1,
+                isMulti: false,
                 selected: new Set(),
                 hasResult: false,
                 isCorrect: false,
@@ -895,10 +896,19 @@
                 markEasy: false,
                 startTs: 0,
                 qInit() {
-                    // 將外層的暫存選項帶進來（若有）
+                    this.loadQuestion(this.$root.quizSet[this.$root.currentIndex]);
+                },
+                loadQuestion(q) {
+                    if (!q) return;
+                    this.q = q;
                     const root = this.$root;
                     this.stat = root.stats[q.id] || root.defaultStat(q.id);
-                    if (root.answers[q.id]) this.selected = new Set(root.answers[q.id]);
+                    this.isMulti = (q.answer?.length || 0) > 1;
+                    this.selected = new Set(root.answers[q.id] || []);
+                    this.hasResult = false;
+                    this.isCorrect = false;
+                    this.expOpen = false;
+                    this.markEasy = false;
                     this.startTs = Date.now();
                 },
                 optionClass(id) {


### PR DESCRIPTION
## Summary
- Correct single-question view so the displayed question updates when navigating
- Refactor `questionVM` to load questions dynamically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b70dff9c4832583fb02c05e6b9d39