### PR TITLE
Pause timer during batch grading and remove answer time stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
                             <button class="btn btn-sm btn-outline-danger" @click="clearAllStats()"><i
                                     class="bi bi-trash3" aria-hidden="true"></i> 清空紀錄</button>
                         </div>
-                        <div class="small-muted mt-2">統計欄位：出題次數、錯誤次數、最後作答選項、是否標記「簡單」、最後作答時間、平均作答秒數…等。</div>
+                        <div class="small-muted mt-2">統計欄位：出題次數、錯誤次數、最後作答選項、是否標記「簡單」…等。</div>
                     </div>
                 </div>
 
@@ -535,7 +535,6 @@
                                     <th>錯誤</th>
                                     <th>正確</th>
                                     <th>正確率</th>
-                                    <th>平均秒數</th>
                                     <th>簡單</th>
                                     <th>最後作答</th>
                                     <th>動作</th>
@@ -550,7 +549,6 @@
                                         <td x-text="row.correct"></td>
                                         <td x-text="(row.attempts? Math.round(row.correct/row.attempts*100):0)+'%'">
                                         </td>
-                                        <td x-text="row.avgTimeSec?.toFixed(1)||'-'"></td>
                                         <td>
                                             <span class="badge rounded-pill" :class="row.easy? 'badge-easy':''"
                                                 x-text="row.easy? '是':'否'"></span>
@@ -617,7 +615,6 @@
                 easyMarkAll: {},        // 一頁所有題模式下的簡單勾選
                 previewSet: [],
                 previewTitle: '',
-                startTime: null,
                 showHelp: false,
                 debugMode: false,
                 // 計時相關
@@ -632,7 +629,7 @@
                 },
 
                 // 紀錄（第二個 JSON）
-                stats: {},              // qid -> { attempts, wrong, correct, lastSelected:[], easy, lastAnsweredAt, avgTimeSec, totalTimeSec }
+                stats: {},              // qid -> { attempts, wrong, correct, lastSelected:[], easy, lastAnsweredAt }
                 filter: { onlyWrong: false, onlyNotEasy: false },
 
                 get statRows() {
@@ -735,7 +732,7 @@
 
                 // —— 紀錄（第二個 JSON）處理 ——
                 defaultStat(id) {
-                    return { id, attempts: 0, wrong: 0, correct: 0, lastSelected: [], easy: false, lastAnsweredAt: null, totalTimeSec: 0, avgTimeSec: 0 };
+                    return { id, attempts: 0, wrong: 0, correct: 0, lastSelected: [], easy: false, lastAnsweredAt: null };
                 },
                 syncStatsWithQuestions() {
                     const map = { ...this.stats };
@@ -754,7 +751,7 @@
                     const file = e.target.files?.[0]; if (!file) return;
                     try {
                         const text = await fileToText(file); const incoming = JSON.parse(text) || {};
-                        // 合併策略：相同題號的 attempts/wrong/correct/時間相加；easy 取 OR；lastSelected/lastAnsweredAt 取較新
+                        // 合併策略：相同題號的 attempts/wrong/correct 相加；easy 取 OR；lastSelected/lastAnsweredAt 取較新
                         const merged = { ...this.stats };
                         for (const [id, s] of Object.entries(incoming)) {
                             if (!merged[id]) { merged[id] = s; continue; }
@@ -767,10 +764,7 @@
                                 lastSelected: (s.lastAnsweredAt > cur.lastAnsweredAt ? s.lastSelected : cur.lastSelected) || [],
                                 easy: !!(cur.easy || s.easy),
                                 lastAnsweredAt: Math.max(cur.lastAnsweredAt || 0, s.lastAnsweredAt || 0) || null,
-                                totalTimeSec: (cur.totalTimeSec || 0) + (s.totalTimeSec || 0),
-                                avgTimeSec: 0,
                             };
-                            const att = merged[id].attempts || 0; merged[id].avgTimeSec = att ? (merged[id].totalTimeSec / att) : 0;
                         }
                         this.stats = merged; this.saveStatsToLS();
                         alert('匯入完成！');
@@ -783,7 +777,7 @@
 
                 // —— 建立出題清單 ——
                 startQuiz(mode) {
-                    this.mode = mode; this.view = 'quiz'; this.currentIndex = 0; this.answers = {}; this.resultMap = {}; this.easyMarkAll = {}; this.startTime = Date.now();
+                    this.mode = mode; this.view = 'quiz'; this.currentIndex = 0; this.answers = {}; this.resultMap = {}; this.easyMarkAll = {};
                     clearInterval(this.timer);
                     const all = this.questions.slice();
                     // 過濾：排除已標簡單
@@ -881,6 +875,7 @@
                     else { this.answers[qid] = new Set([optId]); }
                 },
                 submitAll() {
+                    clearInterval(this.timer);
                     let any = false;
                     for (const q of this.quizSet) {
                         const picked = Array.from(this.answers[q.id] || []);
@@ -914,8 +909,6 @@
                     s.lastAnsweredAt = Date.now();
                     // 簡單標記：僅在答對且有勾選時才成立
                     if (ok && markEasy) s.easy = true;
-                    // 時間：此處取整卷平均；單題模式會在子元件回寫精準時間
-                    const sec = 0; s.totalTimeSec = (s.totalTimeSec || 0) + sec; s.avgTimeSec = (s.attempts ? s.totalTimeSec / s.attempts : 0);
                 },
 
                 // —— 摘要資料容器 ——
@@ -934,7 +927,6 @@
                 isCorrect: false,
                 expOpen: false,
                 markEasy: false,
-                startTs: 0,
                 qInit() {
                     // 監聽根元件的索引與題組變化以載入對應題目
                     this.$watch('$root.currentIndex', (i) => {
@@ -956,7 +948,6 @@
                     this.isCorrect = false;
                     this.expOpen = false;
                     this.markEasy = false;
-                    this.startTs = Date.now();
                 },
                 optionClass(id) {
                     if (!this.hasResult) return '';
@@ -978,7 +969,6 @@
                     if (picked.length === 0) { alert('請先選擇答案'); return; }
                     const ok = this.$root.isCorrectAnswer(this.q.answer, picked);
                     this.hasResult = true; this.isCorrect = ok;
-                    const usedSec = Math.max(0, Math.round((Date.now() - this.startTs) / 1000));
                     // 回寫紀錄
                     if (!this.$root.stats[this.q.id]) this.$root.stats[this.q.id] = this.$root.defaultStat(this.q.id);
                     const s = this.$root.stats[this.q.id];
@@ -987,8 +977,6 @@
                     s.correct = (s.correct || 0) + (ok ? 1 : 0);
                     s.lastSelected = [...picked];
                     s.lastAnsweredAt = Date.now();
-                    s.totalTimeSec = (s.totalTimeSec || 0) + usedSec;
-                    s.avgTimeSec = (s.attempts ? s.totalTimeSec / s.attempts : 0);
                     if (ok && this.markEasy) s.easy = true; // 需答對才成立
                     this.$root.resultMap[this.q.id] = ok ? 'correct' : 'wrong';
                     this.$root.saveStatsToLS();


### PR DESCRIPTION
## Summary
- Pause quiz timer when grading all answers
- Remove answer time column and related tracking fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7961e5dc8325adcb4b453e65a4d1