### PR TITLE
feat: add stats summary and version label

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>純前端出題系統｜Alpine.js</title>
+    <title>純前端出題系統 v1.0.1｜Alpine.js</title>
     <!-- Bootstrap 5 + Icons (純前端好排版) -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
@@ -94,7 +94,7 @@
 
         <!-- 標題列 -->
         <div class="d-flex align-items-center justify-content-between mb-3">
-            <h1 class="h4 mb-0">純前端出題系統 <span class="small text-secondary">｜Alpine.js</span></h1>
+            <h1 class="h4 mb-0">純前端出題系統 <span class="small text-secondary" x-text="version"></span> <span class="small text-secondary">｜Alpine.js</span></h1>
             <div class="d-flex gap-2">
                 <button class="btn btn-outline-secondary btn-sm" data-bs-toggle="collapse" data-bs-target="#recordPanel"
                     aria-expanded="false">
@@ -121,6 +121,31 @@
             <div class="small text-secondary">備註：本系統支援單選/複選（<span class="mono">answer</span> 為陣列，長度 &gt; 1
                 視為複選）。<br>解析欄位可放 HTML，建議使用 <span
                     class="mono">&lt;details&gt;&lt;summary&gt;答案與解析&lt;/summary&gt;...&lt;/details&gt;</span> 結構。</div>
+        </div>
+
+        <!-- 統計摘要 -->
+        <div class="card card-soft mb-4" x-show="view==='home'">
+            <div class="card-body">
+                <h2 class="h6">題庫統計摘要</h2>
+                <div class="row text-center mt-2">
+                    <div class="col-6 col-md-3">
+                        <div class="small-muted">總題數</div>
+                        <div class="h5" x-text="overallStats.total"></div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="small-muted">未作答</div>
+                        <div class="h5 text-warning" x-text="overallStats.unanswered"></div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="small-muted">答錯/作答</div>
+                        <div class="h5 text-danger"><span x-text="overallStats.wrong"></span>/<span x-text="overallStats.totalAttempts"></span></div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="small-muted">正確率</div>
+                        <div class="h5 text-success" x-text="overallStats.accuracy + '%' "></div>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- 載入/設定 卡片 -->
@@ -234,7 +259,6 @@
 
                     <template x-if="quizSet.length>0">
                         <div class="mt-3" x-data="questionVM()" x-init="qInit()"
-                            x-effect="loadQuestion($root.quizSet[$root.currentIndex])"
                             @submit-one.window="onSubmitFromParent($event)">
                             <div class="d-flex align-items-start justify-content-between">
                                 <div>
@@ -617,6 +641,7 @@
                 previewTitle: '',
                 showHelp: false,
                 debugMode: false,
+                version: 'v1.0.1',
                 // 計時相關
                 perQuestionSec: 60,    // 每題秒數
                 timer: null,
@@ -640,7 +665,23 @@
                     return rows;
                 },
 
+                get overallStats() {
+                    const total = this.questions.length;
+                    let unanswered = 0, wrong = 0, correct = 0;
+                    for (const q of this.questions) {
+                        const s = this.stats[q.id] || this.defaultStat(q.id);
+                        if ((s.attempts || 0) === 0) unanswered++;
+                        wrong += s.wrong || 0;
+                        correct += s.correct || 0;
+                    }
+                    const totalAttempts = correct + wrong;
+                    const answered = total - unanswered;
+                    const accuracy = totalAttempts ? Math.round(correct / totalAttempts * 100) : 0;
+                    return { total, unanswered, answered, wrong, correct, totalAttempts, accuracy };
+                },
+
                 async init() {
+                    document.title = `純前端出題系統 ${this.version}｜Alpine.js`;
                     // 從 LocalStorage 載入紀錄
                     this.loadStatsFromLS();
                     await this.loadProjectQuestions();
@@ -929,10 +970,10 @@
                 markEasy: false,
                 qInit() {
                     // 監聽根元件的索引與題組變化以載入對應題目
-                    this.$watch('$root.currentIndex', (i) => {
+                    this.$watch(() => this.$root.currentIndex, i => {
                         this.loadQuestion(this.$root.quizSet[i]);
                     });
-                    this.$watch('$root.quizSet', () => {
+                    this.$watch(() => this.$root.quizSet, () => {
                         this.loadQuestion(this.$root.quizSet[this.$root.currentIndex]);
                     });
                     this.loadQuestion(this.$root.quizSet[this.$root.currentIndex]);


### PR DESCRIPTION
## Summary
- show app version in document title and header
- add home page statistics panel for unanswered and wrong counts
- fix single-question mode by watching root state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ccb4a908325b63e1d8b83a0ffb3