### PR TITLE
Adjust quiz interface defaults and options

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,8 +199,8 @@
                     <div class="col-12 col-md-3">
                         <label class="form-label">版面</label>
                         <select class="form-select" x-model="pageMode">
-                            <option value="one">一頁一題</option>
                             <option value="all">一頁所有題</option>
+                            <option value="one">一頁一題</option>
                         </select>
                     </div>
                     <div class="col-12 col-md-3">
@@ -273,10 +273,15 @@
                                     </button>
                                     <span class="badge rounded-pill mb-1" :class="(stat?.easy)?'badge-easy':''"
                                         x-text="(stat?.easy)?'已標簡單':''"></span>
-                                    <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span class="text-danger"
+                                    <div class="small-muted" x-show="(stat?.attempts||0)>0"><span class="text-danger">錯題</span>/作答：<span class="text-danger"
                                             x-text="stat?.wrong||0"></span>/<span
                                             x-text="stat?.attempts||0"></span></div>
                                 </div>
+                            </div>
+
+                            <div class="form-check mt-2">
+                                <input class="form-check-input" type="checkbox" :id="'unsure_'+q.id" x-model="markUnsure">
+                                <label class="form-check-label" :for="'unsure_'+q.id">這題我不確定</label>
                             </div>
 
                             <div class="mt-3">
@@ -296,10 +301,6 @@
                             </div>
 
                             <div class="d-flex flex-wrap align-items-center gap-3 mt-2">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" :id="'unsure_'+q.id" x-model="markUnsure">
-                                    <label class="form-check-label" :for="'unsure_'+q.id">這題我不確定</label>
-                                </div>
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" :id="'easy_'+q.id"
                                         x-model="markEasy">
@@ -382,8 +383,13 @@
                                         <i class="bi bi-clipboard"></i> 複製
                                     </button>
                                     <span class="badge rounded-pill mb-1" :class="(stats[q.id]?.easy)?'badge-easy':''" x-text="(stats[q.id]?.easy)?'已標簡單':''"></span>
-                                    <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span class="text-danger" x-text="stats[q.id]?.wrong||0"></span>/<span x-text="stats[q.id]?.attempts||0"></span></div>
+                                    <div class="small-muted" x-show="(stats[q.id]?.attempts||0)>0"><span class="text-danger">錯題</span>/作答：<span class="text-danger" x-text="stats[q.id]?.wrong||0"></span>/<span x-text="stats[q.id]?.attempts||0"></span></div>
                                 </div>
+                            </div>
+
+                            <div class="form-check mt-2">
+                                <input class="form-check-input" type="checkbox" :id="'unsure_'+q.id" x-model="unsureMarkAll[q.id]">
+                                <label class="form-check-label" :for="'unsure_'+q.id">這題我不確定</label>
                             </div>
 
                             <div class="mt-3">
@@ -402,10 +408,6 @@
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" :id="'easy_'+q.id" x-model="easyMarkAll[q.id]">
                                     <label class="form-check-label" :for="'easy_'+q.id">這題很簡單不用再出（需答對才算）</label>
-                                </div>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" :id="'unsure_'+q.id" x-model="unsureMarkAll[q.id]">
-                                    <label class="form-check-label" :for="'unsure_'+q.id">這題我不確定</label>
                                 </div>
                             </div>
 
@@ -518,7 +520,7 @@
                                 </div>
                                 <div class="text-end">
                                     <span class="badge rounded-pill me-2" :class="(stats[q.id]?.easy)?'badge-easy':''" x-text="(stats[q.id]?.easy)?'已標簡單':''"></span>
-                                    <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span class="text-danger" x-text="stats[q.id]?.wrong||0"></span>/<span x-text="stats[q.id]?.attempts||0"></span></div>
+                                    <div class="small-muted" x-show="(stats[q.id]?.attempts||0)>0"><span class="text-danger">錯題</span>/作答：<span class="text-danger" x-text="stats[q.id]?.wrong||0"></span>/<span x-text="stats[q.id]?.attempts||0"></span></div>
                                 </div>
                             </div>
                             <div class="mt-3">
@@ -637,7 +639,7 @@
             return {
                 // 狀態
                 view: 'home',            // home | quiz | summary | preview
-                pageMode: 'one',         // one | all
+                pageMode: 'all',         // one | all
                 mode: 'normal',          // normal | review | wrongOnly
                 get modeLabel() { return { normal: '一般測驗', review: '錯題複習（優先）', wrongOnly: '只出錯題' }[this.mode] },
                 questions: [],
@@ -936,7 +938,7 @@
                 copyQuestion(q) {
                     if (!q) return;
                     const opts = (q.options || []).map((opt, i) => `${String.fromCharCode(65 + i)}. ${opt.text}`).join('\n');
-                    const text = `${q.question}\n${opts}`;
+                    const text = `題號：${q.id}\n${q.question}\n${opts}`;
                     navigator.clipboard.writeText(text).then(() => alert('已複製題目與選項'));
                 },
                 submitAll() {


### PR DESCRIPTION
## Summary
- Show question ID when copying questions and options
- Hide 0/0 wrong/attempt stats and relocate "unsure" checkbox between question and options
- Default to showing all questions on one page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bdc1b604c83259c192de44cd285e8