### PR TITLE
Add option to copy bug question IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,6 +637,7 @@
                                 <input type="file" class="d-none" accept=".json,application/json" @change="importBugsFile($event)" />
                             </label>
                             <button class="btn btn-sm btn-outline-secondary" @click="copyAllBugs()"><i class="bi bi-clipboard"></i> 複製全部</button>
+                            <button class="btn btn-sm btn-outline-secondary" @click="copyBugQids()"><i class="bi bi-clipboard"></i> 複製所有題號</button>
                             <button class="btn btn-sm btn-outline-danger" @click="clearAllBugs()"><i class="bi bi-trash3"></i> 清空全部</button>
                         </div>
                     </div>
@@ -1024,6 +1025,11 @@
                 deleteBug(idx) { this.bugs.splice(idx, 1); this.saveBugsToLS(); },
                 clearAllBugs() { if (confirm('清空所有 bug 紀錄？')) { this.bugs = []; this.saveBugsToLS(); } },
                 copyAllBugs() { navigator.clipboard.writeText(JSON.stringify(this.bugs, null, 2)).then(() => alert('已複製所有 bug')); },
+                copyBugQids() {
+                    const ids = this.bugs.map(b => b.qid).filter(q => q);
+                    if (ids.length === 0) { alert('沒有題號可複製'); return; }
+                    navigator.clipboard.writeText(ids.join(', ')).then(() => alert('已複製所有題號'));
+                },
                 saveBugsFile() { downloadJSON(this.bugs, 'bug_reports.json'); },
                 async importBugsFile(e) {
                     const file = e.target.files?.[0]; if (!file) return;


### PR DESCRIPTION
## Summary
- add "copy all question IDs" button to bug report panel
- implement function to copy question IDs to clipboard

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/quiz/package.json')

------
https://chatgpt.com/codex/tasks/task_e_689befaa3c808325bf1d4fda9576921f