### PR TITLE
feat: add analysis view link from summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,6 +499,7 @@
                     <div class="d-flex flex-wrap gap-2 mt-3">
                           <button class="btn btn-outline-secondary" @click="exitQuiz()"><i class="bi bi-house"></i>
                           回首頁</button>
+                        <button class="btn btn-outline-info" @click="viewAllResult()"><i class="bi bi-eye"></i> 看解析</button>
                         <button class="btn btn-outline-danger" x-show="summary.wrong>0" @click="reviewWrong()"><i class="bi bi-journal-text"></i> 查看本次錯題</button>
                         <button class="btn btn-primary" @click="startQuiz(mode)"><i class="bi bi-arrow-repeat"></i>
                             同模式再來一輪</button>
@@ -945,6 +946,12 @@
                     this.previewTitle = '本次錯題與詳解';
                     this.previewSet = arr;
                     this.view = 'preview';
+                },
+                viewAllResult() {
+                    this.pageMode = 'all';
+                    this.showScore = true;
+                    this.view = 'quiz';
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
                 },
                 exitPreview() { this.view = this.prevView || 'home'; },
 


### PR DESCRIPTION
## Summary
- add a "看解析" button in the score summary
- allow users to return to a graded all-question view for review

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c232000188325bd4dd6f20ae02559