### PR TITLE
Fix navigation watchers for single-question view

### DIFF
--- a/index.html
+++ b/index.html
@@ -1273,10 +1273,10 @@
                     // 取得根元件資料
                     this.root = Alpine.$data(this.$root);
                     // 監聽根元件的索引與題組變化以載入對應題目
-                    this.$watch(() => this.root.currentIndex, i => {
+                    this.$watch('root.currentIndex', i => {
                         this.loadQuestion(this.root.quizSet[i]);
                     });
-                    this.$watch(() => this.root.quizSet, () => {
+                    this.$watch('root.quizSet', () => {
                         this.loadQuestion(this.root.quizSet[this.root.currentIndex]);
                     });
                     this.loadQuestion(this.root.quizSet[this.root.currentIndex]);


### PR DESCRIPTION
## Summary
- Ensure the current question updates when moving between questions by watching `root.currentIndex` and `root.quizSet`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c2b740f6883259eea0cc5c2bd2504