### PR TITLE
fix: toggle record and bug panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1100,10 +1100,13 @@
                     const panel = document.getElementById('recordPanel');
                     if (panel) {
                         const bs = bootstrap.Collapse.getOrCreateInstance(panel, { toggle: false });
-                        panel.addEventListener('shown.bs.collapse', () => {
-                            panel.scrollIntoView({ behavior: 'smooth' });
-                        }, { once: true });
-                        bs.show();
+                        const willShow = !panel.classList.contains('show');
+                        if (willShow) {
+                            panel.addEventListener('shown.bs.collapse', () => {
+                                panel.scrollIntoView({ behavior: 'smooth' });
+                            }, { once: true });
+                        }
+                        bs.toggle();
                     }
                 },
                 openBugPanel() {
@@ -1111,10 +1114,13 @@
                     const panel = document.getElementById('bugPanel');
                     if (panel) {
                         const bs = bootstrap.Collapse.getOrCreateInstance(panel, { toggle: false });
-                        panel.addEventListener('shown.bs.collapse', () => {
-                            panel.scrollIntoView({ behavior: 'smooth' });
-                        }, { once: true });
-                        bs.show();
+                        const willShow = !panel.classList.contains('show');
+                        if (willShow) {
+                            panel.addEventListener('shown.bs.collapse', () => {
+                                panel.scrollIntoView({ behavior: 'smooth' });
+                            }, { once: true });
+                        }
+                        bs.toggle();
                     }
                 },
                 openBug(qid) {


### PR DESCRIPTION
## Summary
- toggle the record and bug panels so their buttons can hide them after opening

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c561ffe9c8325a84f36dacd61cbff