### PR TITLE
Move bug copy option to modal and restore scroll buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -647,14 +647,13 @@
             <div class="card card-soft">
                 <div class="card-body">
                     <div class="d-flex align-items-center justify-content-between">
-                        <h2 class="h6 mb-0">Bug 回報區 <small class="text-secondary">(開發者看不到哦，要自行複製給開發者)</small></h2>
+                        <h2 class="h6 mb-0">Bug 回報區</h2>
                         <div class="d-flex flex-wrap gap-2">
                             <button class="btn btn-sm btn-outline-secondary" @click="saveBugsFile()"><i class="bi bi-download"></i> 匯出</button>
                             <label class="btn btn-sm btn-outline-primary mb-0">
                                 <i class="bi bi-upload"></i> 匯入
                                 <input type="file" class="d-none" accept=".json,application/json" @change="importBugsFile($event)" />
                             </label>
-                            <button class="btn btn-sm btn-outline-secondary" @click="copyAllBugs()"><i class="bi bi-clipboard"></i> 複製全部</button>
                             <button class="btn btn-sm btn-outline-secondary" @click="copyBugQids()"><i class="bi bi-clipboard"></i> 複製所有題號</button>
                             <button class="btn btn-sm btn-outline-danger" @click="clearAllBugs()"><i class="bi bi-trash3"></i> 清空全部</button>
                         </div>
@@ -757,8 +756,10 @@
                         <label class="form-label">備註</label>
                         <textarea class="form-control" x-model="editBug.note"></textarea>
                     </div>
+                    <div class="small text-secondary">開發者看不到回報，請使用下方「複製全部」自行傳給開發者。</div>
                 </div>
                 <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary me-auto" @click="copyAllBugs()"><i class="bi bi-clipboard"></i> 複製全部</button>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
                     <button type="button" class="btn btn-primary" @click="saveBug()">儲存</button>
                 </div>
@@ -766,10 +767,10 @@
         </div>
     </div>
 
-    <div x-show="view==='quiz'" class="position-fixed" style="right:1rem; bottom:1rem; z-index:1000;">
+    <div class="position-fixed" style="right:1rem; bottom:1rem; z-index:1000;">
         <div class="d-flex flex-column gap-2">
-            <button class="btn btn-outline-secondary" @click="scrollToTop()"><i class="bi bi-arrow-up"></i></button>
-            <button class="btn btn-outline-secondary" @click="scrollToBottom()"><i class="bi bi-arrow-down"></i></button>
+            <button class="btn btn-outline-secondary btn-sm rounded-circle" @click="scrollToTop()" title="回到頂端"><i class="bi bi-arrow-up"></i></button>
+            <button class="btn btn-outline-secondary btn-sm rounded-circle" @click="scrollToBottom()" title="移到底部"><i class="bi bi-arrow-down"></i></button>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Relocate bug copy feature to the bug creation modal and add explanatory note
- Reintroduce scroll-to-top/bottom controls as compact floating buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5a0bd870832590a9c0a71a5daf79