### PR TITLE
Fix bug status reset after clearing search

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,7 +701,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <template x-for="(b, idx) in filteredBugs()" :key="idx">
+                                <template x-for="b in filteredBugs()" :key="b.qid || b.time">
                                     <tr>
                                         <td class="mono" x-text="b.qid || '-' "></td>
                                         <td x-text="b.issue || '-' "></td>
@@ -716,8 +716,8 @@
                                         </td>
                                         <td>
                                             <div class="btn-group btn-group-sm" role="group">
-                                                <button class="btn btn-outline-primary" @click="openEditBugModal(idx)" title="修改"><i class="bi bi-pencil"></i></button>
-                                                <button class="btn btn-outline-danger" @click="deleteBug(idx)" title="刪除"><i class="bi bi-trash3"></i></button>
+                                                <button class="btn btn-outline-primary" @click="openEditBugModal(b)" title="修改"><i class="bi bi-pencil"></i></button>
+                                                <button class="btn btn-outline-danger" @click="deleteBug(b)" title="刪除"><i class="bi bi-trash3"></i></button>
                                             </div>
                                         </td>
                                     </tr>
@@ -1089,9 +1089,11 @@
                     this.bugModalTitle = '新增 Bug';
                     this.showBugModal();
                 },
-                openEditBugModal(idx) {
+                openEditBugModal(bug) {
+                    const idx = this.bugs.indexOf(bug);
+                    if (idx === -1) return;
                     this.editIndex = idx;
-                    this.editBug = deepClone(this.bugs[idx]);
+                    this.editBug = deepClone(bug);
                     this.editBug.time = this.editBug.time ? new Date(this.editBug.time).toISOString().slice(0,16) : new Date().toISOString().slice(0,16);
                     this.bugModalTitle = '編輯 Bug';
                     this.showBugModal();
@@ -1115,7 +1117,10 @@
                     this.syncBugsWithQuestions();
                     this.bugModal.hide();
                 },
-                deleteBug(idx) { this.bugs.splice(idx, 1); this.saveBugsToLS(); },
+                deleteBug(bug) {
+                    const idx = this.bugs.indexOf(bug);
+                    if (idx !== -1) { this.bugs.splice(idx, 1); this.saveBugsToLS(); }
+                },
                 clearAllBugs() { if (confirm('清空所有 bug 紀錄？')) { this.bugs = []; this.saveBugsToLS(); } },
                 copyAllBugs() { navigator.clipboard.writeText(JSON.stringify(this.bugs, null, 2)).then(() => alert('已複製所有 bug')); },
                 copyBugQids() {


### PR DESCRIPTION
## Summary
- keep bug report row keys stable using each bug's ID to preserve status when clearing search
- adjust edit/delete handlers to operate on bug objects instead of filtered indexes

## Testing
- `python -m json.tool bug_reports.json`

------
https://chatgpt.com/codex/tasks/task_e_689c9914c1208325a1006c7a375eb75f