### PR TITLE
feat: enhance stats record view

### DIFF
--- a/index.html
+++ b/index.html
@@ -616,6 +616,7 @@
                                 <input class="form-check-input" type="checkbox" id="onlyNotEasy" x-model="filter.onlyNotEasy">
                                 <label class="form-check-label" for="onlyNotEasy">只看已標非簡單</label>
                             </div>
+                            <input type="text" class="form-control form-control-sm" placeholder="搜尋題號" x-model="recordSearch" style="width:8rem;" />
                             <button class="btn btn-sm btn-outline-secondary" @click="refreshStatsIds()"><i class="bi bi-arrow-clockwise"></i> 更新題號</button>
                             <!-- <button class="btn btn-sm btn-outline-secondary" @click="saveStatsFile()"><i
                                     class="bi bi-download"></i> 匯出</button> -->
@@ -627,12 +628,20 @@
                         <table class="table align-middle">
                             <thead>
                                 <tr>
-                                    <th>題號</th>
+                                    <th class="pointer" @click="changeSort('id')">題號
+                                        <i class="bi ms-1" :class="sortKey==='id' ? (sortAsc ? 'bi-caret-up-fill' : 'bi-caret-down-fill') : 'bi-arrow-down-up'"></i>
+                                    </th>
                                     <th>作答</th>
-                                    <th>錯誤</th>
+                                    <th class="pointer" @click="changeSort('wrong')">錯誤
+                                        <i class="bi ms-1" :class="sortKey==='wrong' ? (sortAsc ? 'bi-caret-up-fill' : 'bi-caret-down-fill') : 'bi-arrow-down-up'"></i>
+                                    </th>
                                     <th>正確</th>
-                                    <th>正確率</th>
-                                    <th>簡單</th>
+                                    <th class="pointer" @click="changeSort('accuracy')">正確率
+                                        <i class="bi ms-1" :class="sortKey==='accuracy' ? (sortAsc ? 'bi-caret-up-fill' : 'bi-caret-down-fill') : 'bi-arrow-down-up'"></i>
+                                    </th>
+                                    <th class="pointer" @click="changeSort('easy')">簡單
+                                        <i class="bi ms-1" :class="sortKey==='easy' ? (sortAsc ? 'bi-caret-up-fill' : 'bi-caret-down-fill') : 'bi-arrow-down-up'"></i>
+                                    </th>
                                     <th>最後作答</th>
                                     <th>動作</th>
                                 </tr>
@@ -644,8 +653,7 @@
                                         <td x-text="row.attempts"></td>
                                         <td x-text="row.wrong"></td>
                                         <td x-text="row.correct"></td>
-                                        <td x-text="(row.attempts? Math.round(row.correct/row.attempts*100):0)+'%'">
-                                        </td>
+                                        <td x-text="row.accuracy + '%'"></td>
                                         <td>
                                             <span class="badge rounded-pill" :class="row.easy? 'badge-easy':''"
                                                 x-text="row.easy? '是':'否'"></span>
@@ -874,6 +882,9 @@
                 // 紀錄（第二個 JSON）
                 stats: {},              // qid -> { attempts, wrong, correct, lastSelected:[], easy, unsure, lastAnsweredAt }
                 filter: { onlyWrong: true, onlyNotEasy: false },
+                recordSearch: '',
+                sortKey: 'id',
+                sortAsc: true,
 
                 // Bug 回報資料
                 bugs: [],              // { qid, issue, status, note, time }
@@ -885,10 +896,28 @@
                 bugSearch: { qid: '', issue: '', status: '' },
 
                 get statRows() {
-                    let rows = Object.values(this.stats).map(s => ({ ...s }));
+                    let rows = Object.values(this.stats).map(s => {
+                        const attempts = s.attempts || 0;
+                        const correct = s.correct || 0;
+                        return { ...s, id: s.id, attempts, correct, accuracy: attempts ? Math.round(correct / attempts * 100) : 0 };
+                    });
                     if (this.filter.onlyWrong) rows = rows.filter(r => r.wrong > 0);
                     if (this.filter.onlyNotEasy) rows = rows.filter(r => !r.easy);
-                    rows.sort((a, b) => a.id.localeCompare(b.id));
+                    if (this.recordSearch) rows = rows.filter(r => r.id.includes(this.recordSearch.trim()));
+                    const asc = this.sortAsc ? 1 : -1;
+                    rows.sort((a, b) => {
+                        switch (this.sortKey) {
+                            case 'wrong':
+                                return asc * ((a.wrong || 0) - (b.wrong || 0));
+                            case 'easy':
+                                return asc * ((a.easy ? 1 : 0) - (b.easy ? 1 : 0));
+                            case 'accuracy':
+                                return asc * (a.accuracy - b.accuracy);
+                            case 'id':
+                            default:
+                                return asc * a.id.localeCompare(b.id);
+                        }
+                    });
                     return rows;
                 },
 
@@ -1093,7 +1122,18 @@
                             delete this.stats[id];
                         }
                     }
+                    for (const q of this.questions) {
+                        if (!this.stats[q.id]) this.stats[q.id] = this.defaultStat(q.id);
+                    }
                     this.saveStatsToLS();
+                },
+                changeSort(key) {
+                    if (this.sortKey === key) {
+                        this.sortAsc = !this.sortAsc;
+                    } else {
+                        this.sortKey = key;
+                        this.sortAsc = true;
+                    }
                 },
                 toggleEasy(id) { if (!this.stats[id]) return; this.stats[id].easy = !this.stats[id].easy; this.saveStatsToLS(); },
                 clearOne(id) { if (!this.stats[id]) return; if (confirm(`清除此題（${id}）的紀錄？`)) { this.stats[id] = this.defaultStat(id); this.saveStatsToLS(); } },


### PR DESCRIPTION
## Summary
- allow searching and sorting in stats table
- keep stats entries in sync with question IDs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca3497c98832591648c53accb17cd