### PR TITLE
Remove broken cloud upload and streamline quiz HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,11 +217,13 @@
                 </div>
                 
                 <hr class="my-4" />
-                <!-- 開關折疊的按鈕 -->
+                <!-- 開關折疊的按鈕（右上角已有功能，先隱藏） -->
+                <!--
                 <button class="btn btn-outline-secondary mb-3" type="button" data-bs-toggle="collapse"
-                    data-bs-target="#qbankPanel" aria-expanded="false" aria-controls="qbankPanel">
+                    data-bs-target="#qbankPanel" aria-expanded="false" aria-controls="#qbankPanel">
                     題庫與紀錄管理
                 </button>
+                -->
 
                 <!-- 可折疊的內容 -->
                 <div class="collapse" id="qbankPanel">
@@ -234,9 +236,11 @@
                                 尚未載入題庫，可先載入下方「範例題庫」試用。
                             </div>
                             <div class="d-flex flex-wrap gap-2 mt-2">
+                                <!--
                                 <button class="btn btn-sm btn-outline-secondary" @click="loadQuestionsFromDrive()">
                                     <i class="bi bi-cloud-arrow-down"></i> 雲端硬碟
                                 </button>
+                                -->
                                 <button class="btn btn-sm btn-outline-primary" @click="loadSample()">
                                     <i class="bi bi-lightning-charge" aria-hidden="true"></i> 載入範例
                                 </button>
@@ -265,9 +269,11 @@
                                     <input type="file" class="d-none" accept=".json,application/json"
                                         @change="importStatsFile($event)" />
                                 </label>
+                                <!--
                                 <button class="btn btn-sm btn-outline-secondary" @click="importStatsFromDrive()">
                                     <i class="bi bi-cloud-arrow-down"></i> 雲端
                                 </button>
+                                -->
                                 <button class="btn btn-sm btn-outline-danger" @click="clearAllStats()">
                                     <i class="bi bi-trash3" aria-hidden="true"></i> 清空
                                 </button>
@@ -285,14 +291,14 @@
             <div class="card card-soft">
                 <div class="card-body">
                     <div class="d-flex align-items-center justify-content-between sticky-header">
-                        <div class="small-muted">模式：<span x-text="modeLabel"></span> ｜ 進度：<strong
+                        <div class="small-muted"><!-- 模式：--><span x-text="modeLabel"></span> ｜ <!-- 進度：--><strong
                                 x-text="quizSet.length ? currentIndex + 1 : 0"></strong>/<span
-                                x-text="quizSet.length"></span> ｜ 時間：<strong x-text="timeText"></strong></div>
+                                x-text="quizSet.length"></span> ｜ <!-- 時間：--><strong x-text="timeText"></strong></div>
                         <div class="d-flex gap-2">
                             <button class="btn btn-sm btn-outline-secondary" x-show="!timerPaused"
-                                @click="pauseTimer()"><i class="bi bi-pause"></i> 暫停</button>
+                                @click="pauseTimer()" title="暫停"><i class="bi bi-pause"></i><!-- 暫停 --></button>
                             <button class="btn btn-sm btn-outline-secondary" x-show="timerPaused"
-                                @click="resumeTimer()"><i class="bi bi-play"></i> 繼續</button>
+                                @click="resumeTimer()" title="繼續"><i class="bi bi-play"></i><!-- 繼續 --></button>
                             <button class="btn btn-sm btn-outline-secondary" @click="exitQuiz()" title="回到首頁"><i
                                     class="bi bi-house"></i></button>
                         </div>
@@ -400,13 +406,13 @@
             <div class="card card-soft">
                 <div class="card-body">
                     <div class="d-flex align-items-center justify-content-between sticky-header">
-                        <div class="small-muted">模式：<span x-text="modeLabel"></span> ｜ 題數：<strong
-                                x-text="quizSet.length"></strong> ｜ 時間：<strong x-text="timeText"></strong></div>
+                        <div class="small-muted"><!-- 模式：--><span x-text="modeLabel"></span> ｜ <!-- 題數：--><strong
+                                x-text="quizSet.length"></strong> ｜ <!-- 時間：--><strong x-text="timeText"></strong></div>
                         <div class="d-flex gap-2">
                             <button class="btn btn-sm btn-outline-secondary" x-show="!timerPaused"
-                                @click="pauseTimer()"><i class="bi bi-pause"></i> 暫停</button>
+                                @click="pauseTimer()" title="暫停"><i class="bi bi-pause"></i><!-- 暫停 --></button>
                             <button class="btn btn-sm btn-outline-secondary" x-show="timerPaused"
-                                @click="resumeTimer()"><i class="bi bi-play"></i> 繼續</button>
+                                @click="resumeTimer()" title="繼續"><i class="bi bi-play"></i><!-- 繼續 --></button>
                             <button class="btn btn-sm btn-outline-secondary" @click="exitQuiz()" title="回到首頁"><i
                                     class="bi bi-house"></i> </button>
                         </div>
@@ -744,9 +750,11 @@
                                 <input type="file" class="d-none" accept=".json,application/json"
                                     @change="importBugsFile($event)" />
                             </label>
+                            <!--
                             <button class="btn btn-sm btn-outline-secondary" @click="importBugsFromDrive()" title="從雲端匯入">
                                 <i class="bi bi-cloud-arrow-down"></i> 雲端
                             </button>
+                            -->
                             <button class="btn btn-sm btn-outline-secondary" @click="copyAllBugs()"
                                 title="可以把問題一鍵複製傳給我哈哈"><i class="bi bi-clipboard"></i> 全部</button>
                             <button class="btn btn-sm btn-outline-secondary" @click="copyBugQids()"
@@ -905,7 +913,8 @@
             DONE: '已完成'
         });
 
-        // Google Drive Picker configuration
+        // Google Drive Picker configuration（功能移除）
+        /*
         const GOOGLE_API_KEY = 'YOUR_API_KEY';
         const GOOGLE_CLIENT_ID = 'YOUR_CLIENT_ID';
 
@@ -946,6 +955,7 @@
                 }
             });
         }
+        */
 
         // —— Alpine Root ——
         function quizApp() {
@@ -1111,7 +1121,7 @@
                         alert('載入題庫失敗：' + err.message);
                     }
                 },
-                loadQuestionsFromDrive() {
+                /*loadQuestionsFromDrive() {
                     pickFromDrive(text => {
                         try {
                             const arr = JSON.parse(text);
@@ -1124,7 +1134,7 @@
                             alert('載入題庫失敗：' + err.message);
                         }
                     });
-                },
+                },*/
                 loadSample() {
                     // 三題示範（與你提供的格式一致）
                     this.questions = [
@@ -1231,7 +1241,7 @@
                     } catch (err) { alert('匯入失敗：' + err.message); }
                     e.target.value = '';
                 },
-                importStatsFromDrive() {
+                /*importStatsFromDrive() {
                     pickFromDrive(text => {
                         try {
                             const incoming = JSON.parse(text) || {};
@@ -1254,7 +1264,7 @@
                             alert('匯入完成！');
                         } catch (err) { alert('匯入失敗：' + err.message); }
                     });
-                },
+                },*/
                 clearAllStats() { if (confirm('清空所有作答紀錄？')) { this.stats = {}; this.saveStatsToLS(); } },
                 refreshStatsIds() {
                     const valid = new Set(this.questions.map(q => q.id));
@@ -1352,7 +1362,7 @@
                     } catch (err) { alert('匯入失敗：' + err.message); }
                     e.target.value = '';
                 },
-                importBugsFromDrive() {
+                /*importBugsFromDrive() {
                     pickFromDrive(text => {
                         try {
                             const arr = JSON.parse(text);
@@ -1363,7 +1373,7 @@
                             alert('匯入完成！');
                         } catch (err) { alert('匯入失敗：' + err.message); }
                     });
-                },
+                },*/
                 openQbankPanel() {
                     const panel = document.getElementById('qbankPanel');
                     if (panel) {
@@ -1714,7 +1724,7 @@
     </script>
 
     <!-- Bootstrap JS（僅供折疊/元件） -->
-    <script src="https://apis.google.com/js/api.js"></script>
+    <!-- <script src="https://apis.google.com/js/api.js"></script> -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- comment out legacy question bank controls and Google Drive import options
- simplify quiz header to show only values and keep pause/resume as icons
- drop Google Drive picker scripts and related code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cbfadec1083259bdbd6b292dab37c