### PR TITLE
Persist unsure mark when viewing explanation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1661,6 +1661,15 @@
                     this.$watch('root.quizSet', () => {
                         this.loadQuestion(this.root.quizSet[this.root.currentIndex]);
                     });
+                    // 監聽「這題我不確定」變化並寫入紀錄
+                    this.$watch('markUnsure', v => {
+                        if (!this.q) return;
+                        if (!this.root.stats[this.q.id]) {
+                            this.root.stats[this.q.id] = this.root.defaultStat(this.q.id);
+                        }
+                        this.root.stats[this.q.id].unsure = v;
+                        this.root.saveStatsToLS();
+                    });
                     this.loadQuestion(this.root.quizSet[this.root.currentIndex]);
                 },
                 loadQuestion(q) {
@@ -1674,7 +1683,7 @@
                     this.isCorrect = false;
                     this.expOpen = false;
                     this.markEasy = false;
-                    this.markUnsure = false;
+                    this.markUnsure = !!this.stat.unsure;
                 },
                 optionClass(id) {
                     if (!this.hasResult) return '';


### PR DESCRIPTION
## Summary
- remember "I'm unsure" checkbox across interactions in one-question-per-page mode by watching and storing its value

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1a8e040832582bdf7c734948585