### PR TITLE
Use half-width pipe in stats summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,11 +139,9 @@
                         <div class="h5" x-text="overallStats.total"></div>
                     </div>
                     <div class="col-6 col-md-3">
-                        <div class="small-muted">未作答｜未標簡單</div>
+                        <div class="small-muted">未作答 | 未標簡單</div>
                         <div class="h5">
-                            <span class="text-warning" x-text="overallStats.unanswered"></span>
-                            <span class="mx-1">｜</span>
-                            <span class="text-info" x-text="overallStats.notEasy"></span>
+                            <span class="text-warning" x-text="overallStats.unanswered"></span> | <span class="text-info" x-text="overallStats.notEasy"></span>
                         </div>
                     </div>
                     <div class="col-6 col-md-3">


### PR DESCRIPTION
## Summary
- replace full-width separator with half-width pipe and spacing in quiz stats summary.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d216c79ac83259018f9033c3db13b