### PR TITLE
Hide Finish button when disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@
                             <button class="btn btn-primary" @click="submitAll()"><i class="bi bi-check2-circle"></i>
                                 批改全部</button>
                             <button class="btn btn-success" @click="finishAndSummary()"
-                                :disabled="Object.keys(resultMap).length===0"><i class="bi bi-flag"></i> 結束並看成績</button>
+                                x-show="Object.keys(resultMap).length>0"><i class="bi bi-flag"></i> 結束並看成績</button>
                             <button class="btn btn-outline-secondary" x-show="showScore" @click="returnToSummary()"><i
                                     class="bi bi-card-list"></i> 回本次成績</button>
                         </div>


### PR DESCRIPTION
## Summary
- Hide the "finish and view score" button instead of keeping it disabled when no results are available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc0ff72108325a7473cc930181039