### PR TITLE
Respect excludeDevEasy toggle for not-easy counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1283,7 +1283,7 @@
                 get noWrongNotEasyCount() {
                     return this.questions.filter(q => {
                         const s = this.stats[q.id] || {};
-                        return !this.easyIds.has(q.id) && !s.easy && (s.wrong || 0) === 0;
+                        return (!this.excludeDevEasy || !this.easyIds.has(q.id)) && !s.easy && (s.wrong || 0) === 0;
                     }).length;
                 },
 
@@ -1737,7 +1737,7 @@
                     if (mode === 'noWrongNotEasy') {
                         pool = all.filter(q => {
                             const s = this.stats[q.id] || {};
-                            return !this.easyIds.has(q.id) && !s.easy && (s.wrong || 0) === 0;
+                            return (!this.excludeDevEasy || !this.easyIds.has(q.id)) && !s.easy && (s.wrong || 0) === 0;
                         });
                     } else {
                         // 過濾：排除已標簡單及開發者標示簡單


### PR DESCRIPTION
## Summary
- make `未錯且未標簡單題` count obey "排除開發者標記簡單的題目" toggle
- apply same developer-easy filtering when generating quiz set for this mode

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ec129da1083259afb80b6e0840234