### PR TITLE
feat: add question bank filter modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,37 +765,80 @@
             <div class="card card-soft">
                 <div class="card-body">
                     <h2 class="h6 mb-3" x-text="previewTitle"></h2>
-                    <template x-for="(q, idx) in previewSet" :key="q.id">
-                        <div class="border rounded-4 p-3 p-md-4 mb-3">
-                            <div class="d-flex align-items-start justify-content-between">
-                                <div>
-                                    <div class="q-meta">題號：<span class="mono" x-text="q.id"></span> ｜ <span
-                                            x-text="idx+1"></span>/<span x-text="previewSet.length"></span></div>
-                                    <div class="fs-5 mt-1" x-html="md(q?.question || '')"></div>
+                    <template x-if="previewMode==='multi'">
+                        <template x-for="(q, idx) in previewSet" :key="q.id">
+                            <div class="border rounded-4 p-3 p-md-4 mb-3">
+                                <div class="d-flex align-items-start justify-content-between">
+                                    <div>
+                                        <div class="q-meta">題號：<span class="mono" x-text="q.id"></span> ｜ <span
+                                                x-text="idx+1"></span>/<span x-text="previewSet.length"></span></div>
+                                        <div class="fs-5 mt-1" x-html="md(q?.question || '')"></div>
+                                    </div>
+                                    <div class="text-end">
+                                        <span class="badge rounded-pill me-2" :class="(stats[q.id]?.easy)?'badge-easy':''"
+                                            x-text="(stats[q.id]?.easy)?'已標簡單':''"></span>
+                                        <template x-if="(stats[q.id]?.wrong||0)+(stats[q.id]?.attempts||0)>0">
+                                            <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span
+                                                    class="text-danger" x-text="stats[q.id]?.wrong||0"></span>/<span
+                                                    x-text="stats[q.id]?.attempts||0"></span></div>
+                                        </template>
+                                    </div>
                                 </div>
-                                <div class="text-end">
-                                    <span class="badge rounded-pill me-2" :class="(stats[q.id]?.easy)?'badge-easy':''"
-                                        x-text="(stats[q.id]?.easy)?'已標簡單':''"></span>
-                                    <template x-if="(stats[q.id]?.wrong||0)+(stats[q.id]?.attempts||0)>0">
-                                        <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span
-                                                class="text-danger" x-text="stats[q.id]?.wrong||0"></span>/<span
-                                                x-text="stats[q.id]?.attempts||0"></span></div>
+                                <div class="mt-3">
+                                    <template x-for="opt in q.options" :key="opt.id">
+                                        <div class="option-item" :class="q.answer.includes(opt.id) ? 'option-correct' : ''">
+                                            <div class="fw-semibold" x-text="opt.text"></div>
+                                            <div class="small text-secondary" x-show="debugMode">id: <span class="mono"
+                                                    x-text="opt.id"></span></div>
+                                        </div>
                                     </template>
                                 </div>
+                                <details class="mt-2" open>
+                                    <summary class="fw-semibold pointer"><i class="bi bi-journal-text"></i> 答案與解析</summary>
+                                    <div class="mt-2" x-html="md(q.explanation)"></div>
+                                </details>
                             </div>
-                            <div class="mt-3">
-                                <template x-for="opt in q.options" :key="opt.id">
-                                    <div class="option-item" :class="q.answer.includes(opt.id) ? 'option-correct' : ''">
-                                        <div class="fw-semibold" x-text="opt.text"></div>
-                                        <div class="small text-secondary" x-show="debugMode">id: <span class="mono"
-                                                x-text="opt.id"></span></div>
+                        </template>
+                    </template>
+                    <template x-if="previewMode==='single'">
+                        <template x-if="currentPreview">
+                            <div class="border rounded-4 p-3 p-md-4 mb-3">
+                                <div class="d-flex align-items-start justify-content-between">
+                                    <div>
+                                        <div class="q-meta">題號：<span class="mono" x-text="currentPreview.id"></span> ｜ <span
+                                                x-text="previewIndex+1"></span>/<span x-text="previewSet.length"></span></div>
+                                        <div class="fs-5 mt-1" x-html="md(currentPreview?.question || '')"></div>
                                     </div>
-                                </template>
+                                    <div class="text-end">
+                                        <span class="badge rounded-pill me-2"
+                                            :class="(stats[currentPreview.id]?.easy)?'badge-easy':''"
+                                            x-text="(stats[currentPreview.id]?.easy)?'已標簡單':''"></span>
+                                        <template x-if="(stats[currentPreview.id]?.wrong||0)+(stats[currentPreview.id]?.attempts||0)>0">
+                                            <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span
+                                                    class="text-danger" x-text="stats[currentPreview.id]?.wrong||0"></span>/<span
+                                                    x-text="stats[currentPreview.id]?.attempts||0"></span></div>
+                                        </template>
+                                    </div>
+                                </div>
+                                <div class="mt-3">
+                                    <template x-for="opt in currentPreview.options" :key="opt.id">
+                                        <div class="option-item"
+                                            :class="currentPreview.answer.includes(opt.id) ? 'option-correct' : ''">
+                                            <div class="fw-semibold" x-text="opt.text"></div>
+                                            <div class="small text-secondary" x-show="debugMode">id: <span class="mono"
+                                                    x-text="opt.id"></span></div>
+                                        </div>
+                                    </template>
+                                </div>
+                                <details class="mt-2" open>
+                                    <summary class="fw-semibold pointer"><i class="bi bi-journal-text"></i> 答案與解析</summary>
+                                    <div class="mt-2" x-html="md(currentPreview.explanation)"></div>
+                                </details>
                             </div>
-                            <details class="mt-2" open>
-                                <summary class="fw-semibold pointer"><i class="bi bi-journal-text"></i> 答案與解析</summary>
-                                <div class="mt-2" x-html="md(q.explanation)"></div>
-                            </details>
+                        </template>
+                        <div class="d-flex justify-content-between mb-3">
+                            <button class="btn btn-outline-secondary" @click="previewIndex--" :disabled="previewIndex<=0">上一題</button>
+                            <button class="btn btn-outline-secondary" @click="previewIndex++" :disabled="previewIndex>=previewSet.length-1">下一題</button>
                         </div>
                     </template>
                     <div class="d-flex gap-2 mt-2">
@@ -838,7 +881,7 @@
                                     class="bi bi-arrow-clockwise"></i> 更新題號</button> -->
                             <!-- <button class="btn btn-sm btn-outline-secondary" @click="saveStatsFile()"><i
                                     class="bi bi-download"></i> 匯出</button> -->
-                            <button class="btn btn-sm btn-outline-primary" @click="showAllWithExp()"><i
+                            <button class="btn btn-sm btn-outline-primary" @click="openQuestionModal()"><i
                                     class="bi bi-journal-text"></i> 題庫</button>
                             <button class="btn btn-sm btn-outline-danger" @click="showWrongWithExp()"><i
                                     class="bi bi-x-circle"></i> 錯題</button>
@@ -1026,6 +1069,42 @@
             </div>
         </div>
 
+    </div>
+
+    <!-- 題庫篩選 Modal -->
+    <div class="modal fade" id="questionModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">題庫選項</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="qExDevEasy" x-model="questionFilter.excludeDevEasy">
+                        <label class="form-check-label" for="qExDevEasy">排除開發者覺得簡單的</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="qExUserEasy" x-model="questionFilter.excludeUserEasy">
+                        <label class="form-check-label" for="qExUserEasy">排除使用者覺得簡單的</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="qExCorrect" x-model="questionFilter.excludeCorrect">
+                        <label class="form-check-label" for="qExCorrect">排除答對的題目</label>
+                    </div>
+                    <div class="mt-3">
+                        <label class="form-label" for="qDisplay">顯示方式</label>
+                        <select class="form-select" id="qDisplay" x-model="questionFilter.display">
+                            <option value="single">單題</option>
+                            <option value="multi">多題</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" @click="enterQuestionBank()">進入</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Bug 新增/編輯 Modal -->
@@ -1225,6 +1304,11 @@
                 ],// 改這裡
                 previewSet: [],
                 previewTitle: '',
+                previewMode: 'multi',   // multi | single
+                previewIndex: 0,
+                get currentPreview() { return this.previewSet[this.previewIndex]; },
+                questionModal: null,
+                questionFilter: { excludeDevEasy: true, excludeUserEasy: true, excludeCorrect: false, display: 'multi' },
                 showHelp: false,
                 debugMode: false,
                 version: 'v1.0',
@@ -1431,10 +1515,32 @@
                     downloadJSON(this.questions, `question_${nowStamp()}.json`);
                 },
 
+                openQuestionModal() {
+                    if (!this.questionModal) {
+                        this.questionModal = new bootstrap.Modal(document.getElementById('questionModal'));
+                    }
+                    this.questionModal.show();
+                },
+                enterQuestionBank() {
+                    if (this.questionModal) this.questionModal.hide();
+                    let arr = this.questions.slice();
+                    if (this.questionFilter.excludeDevEasy) arr = arr.filter(q => !this.easyIds.has(q.id));
+                    if (this.questionFilter.excludeUserEasy) arr = arr.filter(q => !(this.stats[q.id]?.easy));
+                    if (this.questionFilter.excludeCorrect) arr = arr.filter(q => !(this.stats[q.id]?.correct));
+                    arr.sort((a, b) => a.id.localeCompare(b.id));
+                    this.prevView = this.view;
+                    this.previewTitle = '題庫';
+                    this.previewSet = arr;
+                    this.previewMode = this.questionFilter.display;
+                    this.previewIndex = 0;
+                    this.view = 'preview';
+                },
                 showAllWithExp() {
                     this.prevView = this.view;
                     this.previewTitle = '所有題目與詳解';
                     this.previewSet = [...this.questions].sort((a, b) => a.id.localeCompare(b.id));
+                    this.previewMode = 'multi';
+                    this.previewIndex = 0;
                     this.view = 'preview';
                 },
                 showWrongWithExp() {
@@ -1451,6 +1557,8 @@
                     });
                     this.previewTitle = '錯題與詳解';
                     this.previewSet = arr;
+                    this.previewMode = 'multi';
+                    this.previewIndex = 0;
                     this.view = 'preview';
                 },
                 reviewWrong() {
@@ -1459,6 +1567,8 @@
                     const arr = this.quizSet.filter(q => wrongIds.includes(q.id));
                     this.previewTitle = '本次錯題與詳解';
                     this.previewSet = arr;
+                    this.previewMode = 'multi';
+                    this.previewIndex = 0;
                     this.view = 'preview';
                 },
                 viewAllResult() {


### PR DESCRIPTION
## Summary
- add modal for question bank filtering with developer/user easy and correct toggles
- allow single or multiple preview modes
- wire up new question bank entry flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed8a1d8788325b6dae98dc061681d