### PR TITLE
Fix single-question preview UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -838,36 +838,29 @@
                         </template>
                     </template>
                     <template x-if="previewMode==='single'">
-                        <div class="d-flex justify-content-between mb-3">
-                            <button class="btn btn-outline-secondary" @click="previewIndex--" :disabled="previewIndex<=0">上一題</button>
-                            <button class="btn btn-outline-secondary" @click="previewIndex++" :disabled="previewIndex>=previewSet.length-1">下一題</button>
-                        </div>
-                        <template x-if="currentPreview">
+                        <template x-if="previewSet.length>0">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <button class="btn btn-outline-secondary" @click="previewIndex--" :disabled="previewIndex<=0">上一題</button>
+                                <div class="q-meta">題號：<span class="mono" x-text="currentPreview.id"></span> ｜ <span x-text="previewIndex+1"></span>/<span x-text="previewSet.length"></span></div>
+                                <button class="btn btn-outline-secondary" @click="previewIndex++" :disabled="previewIndex>=previewSet.length-1">下一題</button>
+                            </div>
                             <div class="border rounded-4 p-3 p-md-4 mb-3">
                                 <div class="d-flex align-items-start justify-content-between">
                                     <div>
-                                        <div class="q-meta">題號：<span class="mono" x-text="currentPreview.id"></span> ｜ <span
-                                                x-text="previewIndex+1"></span>/<span x-text="previewSet.length"></span></div>
                                         <div class="fs-5 mt-1" x-html="md(currentPreview?.question || '')"></div>
                                     </div>
                                     <div class="text-end">
-                                        <span class="badge rounded-pill me-2"
-                                            :class="(stats[currentPreview.id]?.easy)?'badge-easy':''"
-                                            x-text="(stats[currentPreview.id]?.easy)?'已標簡單':''"></span>
+                                        <span class="badge rounded-pill me-2" :class="(stats[currentPreview.id]?.easy)?'badge-easy':''" x-text="(stats[currentPreview.id]?.easy)?'已標簡單':''"></span>
                                         <template x-if="(stats[currentPreview.id]?.wrong||0)+(stats[currentPreview.id]?.attempts||0)>0">
-                                            <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span
-                                                    class="text-danger" x-text="stats[currentPreview.id]?.wrong||0"></span>/<span
-                                                    x-text="stats[currentPreview.id]?.attempts||0"></span></div>
+                                            <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span class="text-danger" x-text="stats[currentPreview.id]?.wrong||0"></span>/<span x-text="stats[currentPreview.id]?.attempts||0"></span></div>
                                         </template>
                                     </div>
                                 </div>
                                 <div class="mt-3">
                                     <template x-for="opt in currentPreview.options" :key="opt.id">
-                                        <div class="option-item"
-                                            :class="currentPreview.answer.includes(opt.id) ? 'option-correct' : ''">
+                                        <div class="option-item" :class="currentPreview.answer.includes(opt.id) ? 'option-correct' : ''">
                                             <div class="fw-semibold" x-text="opt.text"></div>
-                                            <div class="small text-secondary" x-show="debugMode">id: <span class="mono"
-                                                    x-text="opt.id"></span></div>
+                                            <div class="small text-secondary" x-show="debugMode">id: <span class="mono" x-text="opt.id"></span></div>
                                         </div>
                                     </template>
                                 </div>
@@ -876,13 +869,16 @@
                                     <div class="mt-2" x-html="md(currentPreview.explanation)"></div>
                                 </details>
                             </div>
+                            <div class="d-flex justify-content-between mb-3">
+                                <button class="btn btn-outline-secondary" @click="previewIndex--" :disabled="previewIndex<=0">上一題</button>
+                                <button class="btn btn-outline-secondary" @click="previewIndex++" :disabled="previewIndex>=previewSet.length-1">下一題</button>
+                            </div>
                         </template>
-                        <div class="d-flex justify-content-between mb-3">
-                            <button class="btn btn-outline-secondary" @click="previewIndex--" :disabled="previewIndex<=0">上一題</button>
-                            <button class="btn btn-outline-secondary" @click="previewIndex++" :disabled="previewIndex>=previewSet.length-1">下一題</button>
-                        </div>
+                        <template x-if="previewSet.length===0">
+                            <div class="alert alert-warning mt-3">此模式下沒有可顯示題目。</div>
+                        </template>
                     </template>
-                    <div class="d-flex gap-2 mt-2">
+<div class="d-flex gap-2 mt-2">
                         <button class="btn btn-outline-secondary" @click="exitPreview()">
                             <i class="bi bi-house"></i> 回首頁
                         </button>


### PR DESCRIPTION
## Summary
- show question text and progress in question bank single-item mode
- warn when no questions available

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m json.tool question.json`

------
https://chatgpt.com/codex/tasks/task_e_689ee84210ec8325b718030a62f5a697