### PR TITLE
Fix single-question preview missing options

### DIFF
--- a/index.html
+++ b/index.html
@@ -857,8 +857,8 @@
                                     </div>
                                 </div>
                                 <div class="mt-3">
-                                    <template x-for="opt in currentPreview.options" :key="opt.id">
-                                        <div class="option-item" :class="currentPreview.answer.includes(opt.id) ? 'option-correct' : ''">
+                                    <template x-for="opt in currentPreview?.options || []" :key="opt.id">
+                                        <div class="option-item" :class="(currentPreview?.answer || []).includes(opt.id) ? 'option-correct' : ''">
                                             <div class="fw-semibold" x-text="opt.text"></div>
                                             <div class="small text-secondary" x-show="debugMode">id: <span class="mono" x-text="opt.id"></span></div>
                                         </div>
@@ -866,7 +866,7 @@
                                 </div>
                                 <details class="mt-2" open>
                                     <summary class="fw-semibold pointer"><i class="bi bi-journal-text"></i> 答案與解析</summary>
-                                    <div class="mt-2" x-html="md(currentPreview.explanation)"></div>
+                                    <div class="mt-2" x-html="md(currentPreview?.explanation || '')"></div>
                                 </details>
                             </div>
                             <div class="d-flex justify-content-between mb-3">


### PR DESCRIPTION
## Summary
- Ensure question bank's single-question view renders answer options and explanations using safe optional access

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eed07c7bc832587703fbc10957e0a