### PR TITLE
Fix photo viewer handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1212,17 +1212,28 @@
     </div>
 
     <!-- Photo viewer -->
-    <!-- <div x-show="photoViewerOpen" x-transition.opacity class="position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-75 d-flex align-items-center justify-content-center" style="z-index:2000;" @click.self="closePhotoViewer()">
-        <div class="position-relative w-100 h-100 d-flex align-items-center justify-content-center" tabindex="0" x-ref="photoViewerPanel" @keydown.left.prevent="prevPhoto()" @keydown.right.prevent="nextPhoto()" @touchstart="photoTouchStartX=$event.touches[0].clientX" @touchend="photoHandleSwipe($event)">
+    <div x-show="photoViewerOpen" x-transition.opacity
+        class="position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-75 d-flex align-items-center justify-content-center"
+        style="z-index:2000;" @click.self="closePhotoViewer()" @keydown.escape.prevent="closePhotoViewer()">
+        <div class="position-relative w-100 h-100 d-flex align-items-center justify-content-center" tabindex="0"
+            x-ref="photoViewerPanel" @keydown.left.prevent="prevPhoto()" @keydown.right.prevent="nextPhoto()"
+            @touchstart="photoTouchStartX=$event.touches[0].clientX" @touchend="photoHandleSwipe($event)">
             <img :src="currentPhoto" class="img-fluid" style="max-height:90vh; max-width:90vw;" x-show="currentPhoto">
             <div class="text-white" x-show="!currentPhoto">無照片</div>
-            <button class="btn btn-light position-absolute top-50 start-0 translate-middle-y ms-2" @click.stop="prevPhoto()"><i class="bi bi-chevron-left"></i></button>
-            <button class="btn btn-light position-absolute top-50 end-0 translate-middle-y me-2" @click.stop="nextPhoto()"><i class="bi bi-chevron-right"></i></button>
-            <button class="btn btn-light position-absolute top-0 end-0 m-2" @click.stop="closePhotoViewer()"><i class="bi bi-x"></i></button>
-            <button class="btn btn-light position-absolute bottom-0 end-0 m-3" @click.stop="toggleFavorite()" :class="{ 'text-danger': isFavorite(currentPhotoName) }"><i :class="isFavorite(currentPhotoName) ? 'bi bi-heart-fill' : 'bi bi-heart'"></i></button>
-            <button class="btn btn-light position-absolute bottom-0 start-0 m-3" @click.stop="toggleShowFav()" :class="{ 'text-danger': showFavOnly }"><i class="bi bi-filter"></i> <i class="bi" :class="showFavOnly ? 'bi-heart-fill' : 'bi-heart'"></i></button>
+            <button class="btn btn-light position-absolute top-50 start-0 translate-middle-y ms-2"
+                @click.stop="prevPhoto()"><i class="bi bi-chevron-left"></i></button>
+            <button class="btn btn-light position-absolute top-50 end-0 translate-middle-y me-2"
+                @click.stop="nextPhoto()"><i class="bi bi-chevron-right"></i></button>
+            <button class="btn btn-light position-absolute top-0 end-0 m-2" @click.stop="closePhotoViewer()"><i
+                    class="bi bi-x"></i></button>
+            <button class="btn btn-light position-absolute bottom-0 end-0 m-3" @click.stop="toggleFavorite()"
+                :class="{ 'text-danger': isFavorite(currentPhotoName) }"><i
+                    :class="isFavorite(currentPhotoName) ? 'bi bi-heart-fill' : 'bi bi-heart'"></i></button>
+            <button class="btn btn-light position-absolute bottom-0 start-0 m-3" @click.stop="toggleShowFav()"
+                :class="{ 'text-danger': showFavOnly }"><i class="bi bi-filter"></i> <i class="bi"
+                    :class="showFavOnly ? 'bi-heart-fill' : 'bi-heart'"></i></button>
         </div>
-    </div> -->
+    </div>
 
     <script>
         // —— 工具函數 ——
@@ -1498,8 +1509,18 @@
                     if (this.photoList.length === 0) {
                         try {
                             const res = await fetch('photo/photos.json');
-                            if (res.ok) { this.photoList = await res.json(); }
-                        } catch (err) { console.warn('載入照片清單失敗', err); }
+                            if (res.ok) {
+                                this.photoList = await res.json();
+                            } else {
+                                console.warn('載入照片清單失敗', res.status);
+                            }
+                        } catch (err) {
+                            console.warn('載入照片清單失敗', err);
+                        }
+                    }
+                    if (this.photoList.length === 0) {
+                        alert('找不到照片資料');
+                        return;
                     }
                     this.showFavOnly = false;
                     this.photoIndex = 0;


### PR DESCRIPTION
## Summary
- Restore photo viewer markup and add escape key handling
- Gracefully abort opening viewer when photos.json is missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f28be9b008325a85d89f6d8649460