### PR TITLE
feat: add toggle for photo viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,7 +276,7 @@
                 <button class="btn btn-outline-secondary btn-sm" @click="openBugPanel()" title="Bug 回報">
                     <i class="bi bi-bug" aria-hidden="true"></i>
                 </button>
-                <button class="btn btn-outline-secondary btn-sm" @click="openPhotoViewer()" title="相簿">
+                <button class="btn btn-outline-secondary btn-sm" x-show="photoFeatureOn" @click="openPhotoViewer()" title="相簿">
                     <i class="bi bi-images" aria-hidden="true"></i>
                 </button>
                 <!-- <button class="btn btn-outline-secondary btn-sm" @click="exitQuiz()" title="回首頁">
@@ -1212,7 +1212,7 @@
     </div>
 
     <!-- Photo viewer -->
-    <div x-show="photoViewerOpen" x-transition.opacity
+    <div x-show="photoViewerOpen && photoFeatureOn" x-transition.opacity
         class="position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-75 d-flex align-items-center justify-content-center"
         style="z-index:2000;" @click.self="closePhotoViewer()" @keydown.escape.prevent="closePhotoViewer()">
         <div class="position-relative w-100 h-100 d-flex align-items-center justify-content-center" tabindex="0"
@@ -1384,6 +1384,7 @@
                 unsureMarkAll: {},      // 一頁所有題模式下的不確定勾選
                 easyFeatureOn: true,   // 啟用 easy.json 功能的開關，改這裡
                 noteFeatureOn: false,  // 啟用筆記功能的開關，改這裡
+                photoFeatureOn: false, // 啟用照片功能的開關，改這裡
                 noteHtml: '',
                 photoViewerOpen: false,
                 photoList: [],
@@ -1506,6 +1507,7 @@
                 get visibleFeatures() { return this.featureList.filter(f => f.show); },
 
                 async openPhotoViewer() {
+                    if (!this.photoFeatureOn) return;
                     if (this.photoList.length === 0) {
                         try {
                             const res = await fetch('photo/photos.json');


### PR DESCRIPTION
## Summary
- add `photoFeatureOn` flag to control photo viewer availability
- hide photo viewer button and panel when feature is disabled
- guard photo viewer loading when disabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2c32bea883259f798842562cf039