### PR TITLE
Remove option highlight in question bank

### DIFF
--- a/index.html
+++ b/index.html
@@ -852,7 +852,7 @@
                                 </div>
                                 <div class="mt-3">
                                     <template x-for="opt in q.options" :key="opt.id">
-                                        <div class="option-item" :class="q.answer.includes(opt.id) ? 'option-correct' : ''">
+                                        <div class="option-item">
                                             <div class="fw-semibold" x-text="opt.text"></div>
                                             <div class="small text-secondary" x-show="debugMode">id: <span class="mono"
                                                     x-text="opt.id"></span></div>
@@ -887,7 +887,7 @@
                                 </div>
                                 <div class="mt-3">
                                     <template x-for="opt in currentPreview?.options || []" :key="opt.id">
-                                        <div class="option-item" :class="(currentPreview?.answer || []).includes(opt.id) ? 'option-correct' : ''">
+                                        <div class="option-item">
                                             <div class="fw-semibold" x-text="opt.text"></div>
                                             <div class="small text-secondary" x-show="debugMode">id: <span class="mono" x-text="opt.id"></span></div>
                                         </div>


### PR DESCRIPTION
## Summary
- Avoid highlighting correct options in the question bank preview, preventing green styling outside quiz submissions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe97d22a88325a0534d518270f28c