### PR TITLE
feat: add copy button in question bank preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -840,8 +840,11 @@
                                                 x-text="idx+1"></span>/<span x-text="previewSet.length"></span></div>
                                         <div class="fs-5 mt-1" x-html="md(q?.question || '')"></div>
                                     </div>
-                                    <div class="text-end">
-                                        <span class="badge rounded-pill me-2" :class="(stats[q.id]?.easy)?'badge-easy':''"
+                                    <div class="text-end d-flex flex-column align-items-end">
+                                        <button class="btn btn-sm btn-outline-secondary mb-2" @click="copyQuestion(q)" title="複製">
+                                            <i class="bi bi-clipboard"></i>
+                                        </button>
+                                        <span class="badge rounded-pill mb-1" :class="(stats[q.id]?.easy)?'badge-easy':''"
                                             x-text="(stats[q.id]?.easy)?'已標簡單':''"></span>
                                         <template x-if="(stats[q.id]?.wrong||0)+(stats[q.id]?.attempts||0)>0">
                                             <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span
@@ -878,8 +881,11 @@
                                     <div>
                                         <div class="fs-5 mt-1" x-html="md(currentPreview?.question || '')"></div>
                                     </div>
-                                    <div class="text-end">
-                                        <span class="badge rounded-pill me-2" :class="(stats[currentPreview.id]?.easy)?'badge-easy':''" x-text="(stats[currentPreview.id]?.easy)?'已標簡單':''"></span>
+                                    <div class="text-end d-flex flex-column align-items-end">
+                                        <button class="btn btn-sm btn-outline-secondary mb-2" @click="copyQuestion(currentPreview)" title="複製">
+                                            <i class="bi bi-clipboard"></i>
+                                        </button>
+                                        <span class="badge rounded-pill mb-1" :class="(stats[currentPreview.id]?.easy)?'badge-easy':''" x-text="(stats[currentPreview.id]?.easy)?'已標簡單':''"></span>
                                         <template x-if="(stats[currentPreview.id]?.wrong||0)+(stats[currentPreview.id]?.attempts||0)>0">
                                             <div class="small-muted"><span class="text-danger">錯題</span>/作答：<span class="text-danger" x-text="stats[currentPreview.id]?.wrong||0"></span>/<span x-text="stats[currentPreview.id]?.attempts||0"></span></div>
                                         </template>


### PR DESCRIPTION
## Summary
- allow copying question and options from question bank preview

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689feace313083258949376048ea888a